### PR TITLE
Add index name

### DIFF
--- a/lib/fluent/plugin/parser_es_slow_query.rb
+++ b/lib/fluent/plugin/parser_es_slow_query.rb
@@ -52,6 +52,7 @@ module Fluent
           'severity' => m['severity'],
           'source' => m['source'],
           'node' => m['node'],
+          'index' => m['index'],
           'took' => m['took'],
           'took_millis' => took_millis,
           'types' => m['types'],

--- a/spec/lib/fluent/plugin/parser_es_slow_query_spec.rb
+++ b/spec/lib/fluent/plugin/parser_es_slow_query_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Fluent::ElasticsearchSlowQueryLogParser do
+RSpec.describe Fluent::Plugin::ElasticsearchSlowQueryLogParser do
   let(:parser) { described_class.new }
 
   describe '#parse' do
@@ -19,6 +19,7 @@ RSpec.describe Fluent::ElasticsearchSlowQueryLogParser do
       expect(log['severity']).to eq('TRACE')
       expect(log['source']).to eq('index.search.slowlog.query')
       expect(log['node']).to eq('m3-hx-corelastic-data1.vinted.net')
+      expect(log['index']).to eq('fr-core-items_20180109082540')
       expect(log['took']).to eq('203m')
       expect(log['took_millis']).to eq(203)
       expect(log['types']).to eq('item')


### PR DESCRIPTION
Funny thing, this was already implemented: 
https://github.com/vinted/fluent-plugin-esslowquery/blob/70279da9cb372b14f0df990293994578b0592ca5/lib/fluent/plugin/parser_es_slow_query.rb#L7


@ernestas-poskus 