### PR TITLE
Support for ES6 slow query log parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ tmp
 .yardoc
 _yardoc
 doc/
+.idea/
+**/*.iml

--- a/lib/fluent/plugin/parser_es_slow_query.rb
+++ b/lib/fluent/plugin/parser_es_slow_query.rb
@@ -14,9 +14,10 @@ module Fluent
       stats = /stats\[(?<stats>)\]/
       search_type = /search_type\[(?<search_type>.*)\]/
       total_shards = /total_shards\[(?<total_shards>\d+)\]/
-      source_body = /source\[(?<source_body>.*)\]/
-
-      REGEXP = /#{time}#{severity}#{source} #{node} #{index}#{shard} #{took}, #{took_millis}, #{types}, #{stats}, #{search_type}, #{total_shards}, #{source_body}/
+      source_body = /source\[(?<source_body>.*)\](\n|, id\[(?<id>.*)\])/
+      total_hits = /total_hits\[(?<total_hits>\d+)\]/
+      
+      REGEXP = /#{time}#{severity}#{source} #{node} #{index}#{shard} #{took}, #{took_millis}(, #{total_hits})?, #{types}, #{stats}, #{search_type}, #{total_shards}, #{source_body}/
       NAMED_QUERY_REGEX = /"_name":\s?"NQ: (?<query_name>.*?)(\|COUNTRY: (?<country>.*?(?=\")))?"/
       TIME_FORMAT = "%Y-%m-%dT%H:%M:%S,%N"
 
@@ -68,6 +69,7 @@ module Fluent
           'country' => nq['country'],
           'source_body_from' => parsed_source_body['from'],
           'source_body_size' => parsed_source_body['size'],
+          'total_hits' => m['total_hits'],
         }
         record["time"] = m['time'] if @keep_time_key
 

--- a/spec/files/elasticsearch-6-slow-query-log.log
+++ b/spec/files/elasticsearch-6-slow-query-log.log
@@ -1,0 +1,1 @@
+[2020-02-17T10:11:49,474][TRACE][index.search.slowlog.query] [m1-machine.net] [de_babies-core-items_20200212093027][57] took[151.4ms], took_millis[151], total_hits[267288], types[item], stats[], search_type[QUERY_THEN_FETCH], total_shards[60], source[{"from":22,"size":22,"timeout":"500ms","query":{"match_all":{}},"_source":false}], id[],

--- a/spec/lib/fluent/plugin/elasticsearch_6_slow_query_log_parser_spec.rb
+++ b/spec/lib/fluent/plugin/elasticsearch_6_slow_query_log_parser_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Fluent::Plugin::ElasticsearchSlowQueryLogParser do
 
     include_context 'elasticsearch query'
 
-    let(:log_text) { File.read('spec/files/elastic.log').lines.first }
+    let(:log_text) { File.read('spec/files/elasticsearch-6-slow-query-log.log').lines.first }
 
     let(:source) {
       query.to_json
@@ -19,19 +19,19 @@ RSpec.describe Fluent::Plugin::ElasticsearchSlowQueryLogParser do
       expect(log['severity']).to eq('TRACE')
       expect(log['source']).to eq('index.search.slowlog.query')
       expect(log['node']).to eq('m1-machine.net')
-      expect(log['index']).to eq('fr-core-items_20190902053448')
-      expect(log['took']).to eq('159.8m')
-      expect(log['took_millis']).to eq(159)
+      expect(log['index']).to eq('de_babies-core-items_20200212093027')
+      expect(log['took']).to eq('151.4m')
+      expect(log['took_millis']).to eq(151)
       expect(log['types']).to eq('item')
       expect(log['stats']).to eq('')
       expect(log['search_type']).to eq('QUERY_THEN_FETCH')
-      expect(log['total_shards']).to eq(100)
-      expect(JSON.parse(log['source_body'])).to eq(query)
-      expect(log['nq']).to eq('regular_items_lookup')
-      expect(log['country']).to eq('BD')
-      expect(log['source_body_from']).to eq(44)
+      expect(log['total_shards']).to eq(60)
+      expect(JSON.parse(log['source_body'])).to eq({"from"=>22, "size"=>22, "timeout"=>"500ms", "query"=>{"match_all"=>{}}, "_source"=>false})
+      expect(log['nq']).to eq('unknown')
+      expect(log['country']).to eq('unknown')
+      expect(log['source_body_from']).to eq(22)
       expect(log['source_body_size']).to eq(22)
-      expect(log['total_hits']).to be_nil
+      expect(log['total_hits']).to eq('267288')
     end
   end
 


### PR DESCRIPTION
* Support ES slow query log parsing
* Track `total_hits` attribute

cc @ernestas-vinted 